### PR TITLE
change dev select shortcut event

### DIFF
--- a/src/main/shadow/grove/dev_support.cljs
+++ b/src/main/shadow/grove/dev_support.cljs
@@ -261,9 +261,9 @@
 
 (defonce keyboard-hook
   (do (js/window.addEventListener
-        "keypress"
+        "keydown"
         (fn [e]
           ;; ctrl+shift+s
-          (when (and (= (.-which e) 19) (.-ctrlKey e) (.-shiftKey e))
+          (when (and (= (.-key e) "S") (.-ctrlKey e) (.-shiftKey e))
             (select-element))))
       true))


### PR DESCRIPTION
This allows shortcut to remain ctrl+shift+s no matter the keyboard layout one uses.