### PR TITLE
Allow setting `:dom/ref` to `nil`

### DIFF
--- a/src/main/shadow/arborist/attributes.cljs
+++ b/src/main/shadow/arborist/attributes.cljs
@@ -306,7 +306,7 @@
 (add-attr :dom/ref
   (fn [env node oval nval]
     (cond
-      (nil? nval)
+      (and oval (nil? nval))
       (vreset! oval nil)
 
       (some? nval)


### PR DESCRIPTION
Example use case: allow _some_ callers of 
```clojure
(defn input [val {:as opts :keys [ref]}]
  (<< [:input {:value val :dom/ref ref}]))
```
to not pass `ref`.